### PR TITLE
Replaced copyright sign

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,4 +3,4 @@ Projector Killer is an Android Application currently in alpha version coded with
 
 # License
 This software is open source but
-Copyright 2016 © Romain ('Elegary'). All rights reserved.
+Copyright 2016 (C) Romain ('Elegary'). All rights reserved.


### PR DESCRIPTION
It's better to use `(C)` instead of `©` for many reasons.